### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An MCP server that generates beautiful Excalidraw architecture diagrams with per
 
 **No API keys. No local models. Works with any AI IDE that supports MCP** (Cursor, Windsurf, Antigravity etc.).
 
+<a href="https://glama.ai/mcp/servers/@BV-Venky/excalidraw-architect-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BV-Venky/excalidraw-architect-mcp/badge" alt="excalidraw-architect-mcp MCP server" />
+</a>
+
 ## The Problem
 
 AI IDEs/LLMs generate diagrams as Mermaid or ASCII art. When they try Excalidraw, they hallucinate coordinates - boxes overlap, arrows cross, and the result needs manual cleanup.


### PR DESCRIPTION
This PR adds a badge for the [excalidraw-architect-mcp](https://glama.ai/mcp/servers/@BV-Venky/excalidraw-architect-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@BV-Venky/excalidraw-architect-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BV-Venky/excalidraw-architect-mcp/badge" alt="excalidraw-architect-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.